### PR TITLE
Fix compiler issue with g++, and provide examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ models/*
 build-info.h
 arm_neon.h
 compile_commands.json
+compiled_*
 
 __pycache__
 

--- a/README.md
+++ b/README.md
@@ -546,3 +546,19 @@ docker run -v /path/to/models:/models ghcr.io/ggerganov/llama.cpp:light -m /mode
 ### Docs
 
 - [GGML tips & tricks](https://github.com/ggerganov/llama.cpp/wiki/GGML-Tips-&-Tricks)
+
+### Grammar Constraints
+
+See https://twitter.com/GrantSlatton/status/1657559506069463040
+
+Compile with `grammar.py` eg
+
+```
+python3 grammar.py --grammar example-grammar_revolution.txt > compiled_revolution
+
+python3 grammar.py --json example-grammar_tourism-json.txt > compiled_tourism
+```
+
+When running, pass the constraining grammar with `--grammar <file>`, and use `-p prompt` to provide the context for the output
+
+eg `./main -m ./models/7B/ggml-model-q4_0.bin -c 512 -b 1024 -n 256 --keep 48 --grammar compiled_tourism -p "Sydney"`

--- a/example-grammar_revolution.txt
+++ b/example-grammar_revolution.txt
@@ -1,0 +1,4 @@
+country_adjective = "American" | "French" | "Iranian"
+digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
+year = <digit> <digit> <digit> <digit>
+sentence = "The " <country_adjective> " revolution started in " <year> "."

--- a/example-grammar_tourism-json.txt
+++ b/example-grammar_tourism-json.txt
@@ -1,0 +1,8 @@
+type CittyData = {
+   "city_name": string,
+   "country": string,
+   "reasons_to_visit": {
+      "perecent_sunny_days": number,
+      "top_3_tourist_attractions": [string, string, string],
+   },
+};

--- a/example-grammar_tourism-json.txt
+++ b/example-grammar_tourism-json.txt
@@ -1,4 +1,4 @@
-type CittyData = {
+type CityData = {
    "city_name": string,
    "country": string,
    "reasons_to_visit": {

--- a/llama.cpp
+++ b/llama.cpp
@@ -205,16 +205,16 @@ struct llama_vocab {
     std::vector<token_score> id_to_token;
 
     struct token_trie {
-        std::unordered_map<char, token_trie> children;
+        std::unordered_map<char, token_trie*> children;
         std::vector<llama_vocab::id> tokens;
 
         void insert(const llama_vocab::token & tok, llama_vocab::id id) {
             token_trie * node = this;
             for (char c : tok) {
                 if (node->children.count(c) == 0) {
-                    node->children[c] = token_trie();
+                    node->children[c] = new token_trie();
                 }
-                node = &node->children.at(c);
+                node = node->children.at(c);
             }
             node->tokens.push_back(id);
         }
@@ -3019,7 +3019,7 @@ struct token_grammar {
 
             auto cloned_validator = clone();
             if(cloned_validator->accept(c)) {
-                cloned_validator->collect_ids(depth+1, child_trie, ids);
+                cloned_validator->collect_ids(depth+1, *child_trie, ids);
             }
         }
     }


### PR DESCRIPTION
When I try to compile this on Ubuntu 20.04 or 22.04, it fails with the error

```
/usr/include/c++/9/bits/unordered_map.h:105:18:   required from ‘class std::unordered_map<char, llama_vocab::token_trie>’
llama.cpp:208:46:   required from here
/usr/include/c++/9/bits/stl_pair.h:215:11: error: ‘std::pair<_T1, _T2>::second’ has incomplete type
  215 |       _T2 second;                /// @c second is a copy of the second object
      |           ^~~~~~
```

One of my colleagues who knows a lot of C++ suggested the attached patch, which fixes it for g++

Also includes (slightly tweaked) versions of the example grammars from your tweet about it, and steps required to run them for different countries/cities